### PR TITLE
Bump workflow actions to Node 24 versions

### DIFF
--- a/.github/workflows/update-sermons.yml
+++ b/.github/workflows/update-sermons.yml
@@ -15,9 +15,9 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
Clears the GitHub Actions Node 20 deprecation warning on the "Update Sunday services" workflow.

- `actions/checkout@v4` → `@v5`
- `actions/setup-python@v5` → `@v6`

Both current majors run on Node 24. No behavior change; the workflow already runs green on master. This just avoids the forced-migration breakage (Node 20 removed from runners 2026-09-16).