### PR TITLE
Fix blank gaps in Sermons grid

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -682,3 +682,11 @@ footer li {
   width: 100%;
   height: 100%;
 }
+
+/* Sermons grid: use flex-wrap so cards with different title heights don't
+   snag on each other's floats (Bootstrap 3 col-* are floated, which leaves
+   blank gaps when rows are uneven). */
+.sermons-grid {
+  display: flex;
+  flex-wrap: wrap;
+}

--- a/resources/index.html
+++ b/resources/index.html
@@ -23,7 +23,7 @@ title: Resources
   </div>
 </div>
 
-<div class="row mb90">
+<div class="row mb90 sermons-grid">
   <div class="col-md-12 text-center">
     <h2><strong>Sermons</strong></h2>
     <p>Watch our most recent Sunday services. View the full library on our


### PR DESCRIPTION
## Problem
The Sermons grid showed blank gaps that looked like missing videos. They weren't — the data is clean and all thumbnails load. The cause is Bootstrap 3's floated `col-*`: when a sermon title wraps to two lines (e.g. "Overflow Retreat - Sunday Service"), the taller card makes the next row snag instead of clearing, leaving a hole.

## Fix
Add a scoped CSS rule and apply it to the sermons row:
```css
.sermons-grid { display: flex; flex-wrap: wrap; }
```
Rows now align regardless of title height, at every breakpoint (desktop 3-up, tablet 2-up, mobile 1-up). Verified with a before/after render against the live 9 videos.