### PR TITLE
Site updates: Young Adults, FiCB buttons, deacons, mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site/
 .idea/
 __pycache__/
 *.pyc
+.claude/settings.local.json

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,7 +22,6 @@
               Millbrae, CA 94030<br/>
               (650) 557-4440<br/>
               <a href="mailto:office@christcentralsf.com">office@christcentralsf.com</a><br/>
-              <a class="hidden-xs" data-toggle="modal" data-target="#contact" href="#">Contact Us</a>
           </p>
           </div>
           <div class="col-lg-5">
@@ -54,7 +53,7 @@
         </div>
         <div class="row">
           <div class="col-md-12">
-            <p class="copyright">Version 8.1.0 &copy; 2014-2023 Christ Central. All rights reserved.</p>
+            <p class="copyright">Version 8.2.0 &copy; 2014-2026 Christ Central. All rights reserved.</p>
           </div>
         </div>
       </div>

--- a/about/index.html
+++ b/about/index.html
@@ -3,12 +3,6 @@ layout: default
 title: About
 ---
 
-<div class="row mb60">
-  <div class="col-md-12 relative">
-    <img src="/assets/images/about_header.png" />
-  </div>
-</div>
-
 {% include vision.html %}
 
 <div class="row" id="core-values">
@@ -129,59 +123,54 @@ title: About
   </div>
   <div class="col-sm-6 col-md-3">
     <p><strong>Ordained Deacons</strong></p>
-    <ul class="servants-list">
-      <li>Mark Hur</li>
-      <li>Min Park</li>
-      <li>Sam Min</li>
-      <li>Tommy Lee</li>
-    </ul>
-  </div>
-  <div class="col-sm-6 col-md-3">
-    <p><strong>East Bay Deacons</strong></p>
     <div class="col-lg-6">
       <ul class="servants-list mlm15">
+        <li>Mark Hur</li>
+        <li>Min Park</li>
+        <li>Sam Min</li>
+        <li>Tommy Lee</li>
         <li>Brian Kim</li>
-        <li>Christine Lee</li>
         <li>Dan Ha</li>
-        <li>Hamee Ha</li>
         <li>James Won</li>
-        <li>Katrina Kim</li>
-        <li>Luxi Choi</li>
-      </ul>
-    </div>
-    <div class="col-lg-6">
-      <ul class="servants-list mlm15">
-        <li>Ping Sui</li>
         <li>Rob Hoang</li>
-        <li>Sam Lee</li>
+      </ul>
+    </div>
+    <div class="col-lg-6">
+      <ul class="servants-list mlm15">
         <li>Sammy Pak</li>
-        <li>Suddie Choi</li>
+        <li>Sam Lee</li>
         <li>William Wong</li>
-      </ul>
-    </div>
-  </div>
-  <div class="col-sm-6 col-md-3">
-    <p><strong>Peninsula Deacons</strong></p>
-    <div class="col-lg-6">
-      <ul class="servants-list mlm15">
-        <li>Albert Yi</li>
-        <li>Andrew Shinn</li>
-        <li>Darren Chan</li>
-        <li>Greg Afong</li>
-        <li>Hojin Lee</li>
         <li>Hyunmin Hong</li>
-        <li>Jae Son Chan</li>
-      </ul>
-    </div>
-    <div class="col-lg-6">
-      <ul class="servants-list mlm15">
-        <li>Jen Ku</li>
-        <li>Lisa Yi</li>
-        <li>Malissa Kim</li>
         <li>Michael Moon</li>
         <li>Mike Kim</li>
         <li>Stephan Kim</li>
+        <li>In Cho</li>
       </ul>
     </div>
+  </div>
+  <div class="col-sm-6 col-md-3">
+    <p><strong>East Bay Deacons</strong></p>
+    <ul class="servants-list">
+      <li>Christine Lee</li>
+      <li>Hamee Ha</li>
+      <li>Katrina Kim</li>
+      <li>Luxi Choi</li>
+      <li>Ping Sui</li>
+      <li>Suddie Choi</li>
+    </ul>
+  </div>
+  <div class="col-sm-6 col-md-3">
+    <p><strong>Peninsula Deacons</strong></p>
+    <ul class="servants-list">
+      <li>Albert Yi</li>
+      <li>Andrew Shinn</li>
+      <li>Darren Chan</li>
+      <li>Greg Afong</li>
+      <li>Hojin Lee</li>
+      <li>Jae Son Chan</li>
+      <li>Jen Ku</li>
+      <li>Lisa Yi</li>
+      <li>Malissa Kim</li>
+    </ul>
   </div>
 </div>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -690,3 +690,86 @@ footer li {
   display: flex;
   flex-wrap: wrap;
 }
+
+/* ===== Mobile optimizations ===== */
+@media (max-width: 767px) {
+  h1 {
+    font-size: 28px;
+  }
+
+  h2 {
+    font-size: 20px;
+  }
+
+  .worship-item {
+    height: auto;
+    margin-bottom: 30px;
+  }
+
+  .ficb-banner-inner .btn-primary,
+  .ficb-banner-button {
+    display: block;
+    text-align: center;
+  }
+
+  footer .link-content {
+    margin-top: 30px;
+  }
+
+  footer .link-content h1 {
+    font-size: 24px;
+  }
+
+  footer .flex {
+    flex-wrap: wrap;
+  }
+
+  footer .ml30 {
+    margin-left: 0;
+    margin-top: 15px;
+  }
+
+  .three-steps {
+    padding: 30px 15px 0 15px;
+  }
+
+  .three-steps .step {
+    height: auto;
+    margin: 0 0 30px 0;
+  }
+
+  .three-steps .col-md-12.three-columns {
+    display: block;
+  }
+
+  .header-banner-title-center {
+    position: relative;
+    top: auto;
+    left: auto;
+    transform: none;
+    text-align: center;
+    padding: 20px 0;
+  }
+
+  .mb90 {
+    margin-bottom: 40px;
+  }
+
+  .mb120 {
+    margin-bottom: 40px;
+  }
+
+  .mb60 {
+    margin-bottom: 30px;
+  }
+
+  hr {
+    margin-top: 40px;
+    margin-bottom: 40px;
+  }
+
+  .quote {
+    font-size: 24px;
+    padding: 30px 0;
+  }
+}

--- a/ficb/index.html
+++ b/ficb/index.html
@@ -8,7 +8,8 @@ title: FiCB
     <img src="/assets/images/ficb/ficb_1.png" />
     <div class="col-md-3 ficb-banner-inner">
       <h2>Fellowship in Christ,<br>Berkeley (FiCB)</h2>
-      <a class="btn btn-primary" href="https://www.facebook.com/groups/ficbsays">Join us</a>
+      <a class="btn btn-primary" style="margin-bottom: 5px;" href="https://www.facebook.com/groups/ficbsays/info/">Join Us on Facebook</a>
+      <a class="btn btn-primary" href="https://www.instagram.com/humansofficb/">Join Us on Instagram</a>
     </div>
   </div>
 </div>
@@ -85,7 +86,8 @@ title: FiCB
     <p><strong>CONNECT</strong></p>
     <h2>Don't be shy, we'd love to<br>get to know you!</h2>
     <p>Join our <a href="https://www.facebook.com/groups/ficbsays">Facebook group</a>, and follow us on <a href="https://www.instagram.com/humansofficb">Instagram</a> for most up-to-date news and announcements. If you have any questions about upcoming events or want to get involved, shoot us an e-mail at <a href="mailto:college@christcentralsf.com">college@christcentralsf.com</a>.</p>
-    <a class="btn ficb-banner-button mt30" href="https://www.facebook.com/groups/ficbsays">Join us</a>
+    <a class="btn ficb-banner-button mt30" style="margin-bottom: 5px;" href="https://www.facebook.com/groups/ficbsays/info/">Join Us on Facebook</a>
+    <a class="btn ficb-banner-button mt30" href="https://www.instagram.com/humansofficb/">Join Us on Instagram</a>
   </div>
   <div class="col-md-6 col-xs-12">
     <img src="/assets/images/ficb/connect.png" />

--- a/index.html
+++ b/index.html
@@ -37,8 +37,9 @@ title: Home
         <ul style="padding-left: 15px;">
             <li>Family Life Ministry</li>
             <li>
-                <a href="https://christcentralsf.churchcenter.com/groups/christ-central-fellowship-groups/adults-ministry">Adult
-                    Ministry</a></li>
+                <a href="https://christcentralsf.churchcenter.com/groups/christ-central-life-stage-ministries/young-adults-east-bay">Young Adults (East Bay)</a></li>
+            <li>
+                <a href="https://christcentralsf.churchcenter.com/groups/christ-central-life-stage-ministries/young-adults-peninsula">Young Adults (Peninsula)</a></li>
             <li>College Ministry (<a href="https://www.christcentralsf.com/ficb/">Berkeley</a>)</li>
             <li>Youth Group</li>
             <li>Education Ministry</li>


### PR DESCRIPTION
## Summary
- Replace Adult Ministry link with two Young Adults group links (East Bay & Peninsula)
- FiCB page: split single "Join us" button into Facebook + Instagram buttons with spacing
- About page: updated Ordained Deacons list, removed header image, removed Contact Us modal link from footer
- Footer: bumped version to 8.2.0, copyright to 2014-2026
- Mobile CSS: font scaling, auto heights for worship items, flex-wrap for footer, reduced margins

## Test plan
- [ ] Verify homepage Young Adults links go to correct churchcenter.com pages
- [ ] Check FiCB page buttons render with gap on desktop and mobile
- [ ] Confirm About page deacon lists match current roster
- [ ] Verify footer shows v8.2.0 and no Contact Us link
- [ ] Test mobile responsiveness across pages via Netlify deploy preview